### PR TITLE
Python code to load geometry fixed for SBND

### DIFF
--- a/sbnalg/gallery/python/LArSoftUtils.py
+++ b/sbnalg/gallery/python/LArSoftUtils.py
@@ -158,9 +158,6 @@ def loadWireReadout(
     SourceCode.loadHeaderFromUPS('larcorealg/Geometry/WireReadoutSorterStandard.h')
     sorterClass = ROOT.geo.WireReadoutSorterStandard
 
-  SourceCode.loadHeaderFromUPS('icarusalg/Geometry/ICARUSstandaloneGeometrySetup.h')
-  SourceCode.loadLibrary("icarusalg_Geometry")
-
   service = ROOT.lar.standalone.SetupReadout[sorterClass,serviceClass](serviceConfig, geometry)
   if registry: registry.register(serviceName, service)
 


### PR DESCRIPTION
During the update of Python code for LArSoft v10, Python libraries to load services was ported to `sbnalg`. It turns out that some ICARUS-specific code sneaked back in.
This pull request fixed that: the two spurious lines are superfluous for ICARUS and breaking SBND, and have been removed.

The change was tested with `icaruscode` and `sbndcode` `v10_06_00[_01]`.

As a thank for reporting the issue, I suggest the following reviewers:
 * @tbwester, reporter
 * @marcodeltutto, co-author of the port above
