### PR TITLE
Rename Test and AssnsCrosser_test libraries to avoid cmake name collision with icarusalg test libraries

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 include(CetTest)
 
 cet_make_library(
-  LIBRARY_NAME Test
+  LIBRARY_NAME Test_sbnalg
   INTERFACE
   SOURCE
     FrameworkEventMockup.h

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -1,7 +1,8 @@
-cet_test(AssnsCrosser_test
+cet_test(AssnsCrosser_test_sbnalg
+  SOURCE AssnsCrosser_test.cc
   LIBRARIES
     sbnalg::Utilities
-    sbnalg::Test
+    sbnalg::Test_sbnalg
     canvas::canvas
     cetlib::cetlib
   USE_BOOST_UNIT


### PR DESCRIPTION
@hgreenlee please test and merge